### PR TITLE
Updated jvmtop download URL

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@ src_filepath = "#{Chef::Config['file_cache_path']}/#{src_filename}"
 extract_path = "/usr/local/jvmtop"
 
 remote_file "#{Chef::Config[:file_cache_path]}/jvmtop-#{node[:jvmtop][:version]}.tar.gz" do
-  source "https://jvmtop.googlecode.com/files/jvmtop-#{node[:jvmtop][:version]}.tar.gz"
+  source "https://github.com/patric-r/jvmtop/releases/download/#{node[:jvmtop][:version]}/jvmtop-#{node[:jvmtop][:version]}.tar.gz"
   owner 'root'
   group 'root'
 end


### PR DESCRIPTION
The googlecode.com url appears to no longer be a valid download location.  Switched to the download url as found on jvmtop github page.
